### PR TITLE
Enable compatibility flag for PPL

### DIFF
--- a/Source/Modules.lvproj
+++ b/Source/Modules.lvproj
@@ -154,7 +154,7 @@
 				<Property Name="Bld_modifyLibraryFile" Type="Bool">true</Property>
 				<Property Name="Bld_previewCacheID" Type="Str">{340947CB-E0C0-4DFB-9B14-C6B14222715D}</Property>
 				<Property Name="Bld_targetDestDir" Type="Path">/Pharlap</Property>
-				<Property Name="Bld_version.build" Type="Int">125</Property>
+				<Property Name="Bld_version.build" Type="Int">126</Property>
 				<Property Name="Bld_version.major" Type="Int">1</Property>
 				<Property Name="Destination[0].destName" Type="Str">Modules.lvlibp</Property>
 				<Property Name="Destination[0].path" Type="Path">/Pharlap/NI_AB_PROJECTNAME.lvlibp</Property>
@@ -165,7 +165,7 @@
 				<Property Name="Destination[1].path" Type="Path">/Pharlap</Property>
 				<Property Name="Destination[1].path.type" Type="Str">&lt;none&gt;</Property>
 				<Property Name="DestinationCount" Type="Int">2</Property>
-				<Property Name="Source[0].itemID" Type="Str">{46CAAE65-884D-4554-9610-CD6FC13134AD}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{231E7BF0-7F42-4041-A649-0BEEC0B9C501}</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
 				<Property Name="Source[1].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[1].itemID" Type="Ref">/RT PXI Target/Modules.lvlib</Property>
@@ -182,6 +182,7 @@
 				<Property Name="TgtF_productName" Type="Str">Modules</Property>
 				<Property Name="TgtF_targetfileGUID" Type="Str">{72FD8574-836E-4130-8462-29E82838B790}</Property>
 				<Property Name="TgtF_targetfileName" Type="Str">Modules.lvlibp</Property>
+				<Property Name="TgtF_versionIndependent" Type="Bool">true</Property>
 			</Item>
 			<Item Name="NI ECAT Remote IO" Type="Source Distribution">
 				<Property Name="Bld_buildCacheID" Type="Str">{886BFD7E-178C-4696-885C-26F32CC6E6A1}</Property>
@@ -343,15 +344,15 @@
 				<Property Name="Bld_version.build" Type="Int">3</Property>
 				<Property Name="Bld_version.major" Type="Int">1</Property>
 				<Property Name="Destination[0].destName" Type="Str">Modules.lvlibp</Property>
-				<Property Name="Destination[0].path" Type="Path">/VxWorks/NI_AB_PROJECTNAME.lvlibp</Property>
+				<Property Name="Destination[0].path" Type="Path">/NI_AB_TARGETNAME/NI_AB_PROJECTNAME.lvlibp</Property>
 				<Property Name="Destination[0].path.type" Type="Str">&lt;none&gt;</Property>
 				<Property Name="Destination[0].preserveHierarchy" Type="Bool">true</Property>
 				<Property Name="Destination[0].type" Type="Str">App</Property>
 				<Property Name="Destination[1].destName" Type="Str">Support Directory</Property>
-				<Property Name="Destination[1].path" Type="Path">/VxWorks</Property>
+				<Property Name="Destination[1].path" Type="Path">/NI_AB_TARGETNAME</Property>
 				<Property Name="Destination[1].path.type" Type="Str">&lt;none&gt;</Property>
 				<Property Name="DestinationCount" Type="Int">2</Property>
-				<Property Name="Source[0].itemID" Type="Str">{9FCE1876-F468-4A18-B448-66BBE8D805E8}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{DA08E109-A32E-4FFD-B66F-240E6BAE4EF6}</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
 				<Property Name="Source[1].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[1].itemID" Type="Ref">/VxWorks/Modules.lvlib</Property>
@@ -368,6 +369,7 @@
 				<Property Name="TgtF_productName" Type="Str">Modules</Property>
 				<Property Name="TgtF_targetfileGUID" Type="Str">{9AB5E24E-C7AB-4774-9B71-B4F6EF678B9A}</Property>
 				<Property Name="TgtF_targetfileName" Type="Str">Modules.lvlibp</Property>
+				<Property Name="TgtF_versionIndependent" Type="Bool">true</Property>
 			</Item>
 			<Item Name="NI ECAT Remote IO" Type="Source Distribution">
 				<Property Name="Bld_buildCacheID" Type="Str">{6B5A7CED-8101-4532-9FC8-76DA68F0537E}</Property>
@@ -537,7 +539,7 @@
 				<Property Name="Destination[1].path" Type="Path">/Linux_32_ARM</Property>
 				<Property Name="Destination[1].path.type" Type="Str">&lt;none&gt;</Property>
 				<Property Name="DestinationCount" Type="Int">2</Property>
-				<Property Name="Source[0].itemID" Type="Str">{89CA1CDF-754C-4985-AEDF-6E36429DEF01}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{56EAF20D-0C37-4069-A86D-623D8C489038}</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
 				<Property Name="Source[1].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[1].itemID" Type="Ref">/Linux 32 ARM/Modules.lvlib</Property>
@@ -554,6 +556,7 @@
 				<Property Name="TgtF_productName" Type="Str">Modules</Property>
 				<Property Name="TgtF_targetfileGUID" Type="Str">{1B259735-B215-43D3-9EEB-60870D841E39}</Property>
 				<Property Name="TgtF_targetfileName" Type="Str">Modules.lvlibp</Property>
+				<Property Name="TgtF_versionIndependent" Type="Bool">true</Property>
 			</Item>
 			<Item Name="NI ECAT Remote IO" Type="Source Distribution">
 				<Property Name="Bld_buildCacheID" Type="Str">{894A9294-9A60-4C47-8E36-5897761D91FB}</Property>
@@ -724,7 +727,7 @@
 				<Property Name="Destination[1].path" Type="Path">/Linux_x64</Property>
 				<Property Name="Destination[1].path.type" Type="Str">&lt;none&gt;</Property>
 				<Property Name="DestinationCount" Type="Int">2</Property>
-				<Property Name="Source[0].itemID" Type="Str">{61CD4088-68BD-4E3F-87B3-359E3F4B3418}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{0672587C-6AC1-4176-B49E-AAE0BD56862E}</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
 				<Property Name="Source[1].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[1].itemID" Type="Ref">/Linux x64/Modules.lvlib</Property>
@@ -741,6 +744,7 @@
 				<Property Name="TgtF_productName" Type="Str">Modules</Property>
 				<Property Name="TgtF_targetfileGUID" Type="Str">{5BF25CEC-F983-4944-9C48-4628C0382142}</Property>
 				<Property Name="TgtF_targetfileName" Type="Str">Modules.lvlibp</Property>
+				<Property Name="TgtF_versionIndependent" Type="Bool">true</Property>
 			</Item>
 			<Item Name="NI ECAT Remote IO" Type="Source Distribution">
 				<Property Name="Bld_buildCacheID" Type="Str">{97AF9D2A-7804-4F1A-8813-F50F8510D530}</Property>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-module-libraries/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Enables the forward compatibility flag in the build specs for the packed library.

### Why should this Pull Request be merged?

This appears to fix some intra-release LabVIEW versioning issues.

### What testing has been done?

The custom device built without this flag set failed to execute on a specific machine; enabling this flag fixed it on that specific machine.