### PR TITLE
Add 2023 to build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,8 +3,8 @@
 @Library('vs-build-tools') _
 
 def lvVersions = [
-  32 : ['2019', '2020', '2021'],
-  64 : ['2021']
+  32 : ['2019', '2020', '2021', '2023'],
+  64 : ['2021', '2023']
 ]
 
 ni.vsbuild.PipelineExecutor.execute(this, 'vs_cd_build', lvVersions)

--- a/build.toml
+++ b/build.toml
@@ -12,7 +12,7 @@ project = '{modules}'
 target = 'My Computer'
 build_spec = 'Modules'
 bitness = '64'
-bitness_versions = ['2021']
+bitness_versions = ['2021', '2023']
 
 [[build.steps]]
 name = 'Scan Engine Module Libraries'
@@ -21,7 +21,7 @@ project = '{modules}'
 target = 'Linux x64'
 build_spec = 'Modules'
 bitness = '32'
-bitness_versions = ['2021']
+bitness_versions = ['2021', '2023']
 
 [[build.steps]]
 name = 'Scan Engine Remote IO Libraries'
@@ -30,7 +30,7 @@ project = '{modules}'
 target = 'My Computer'
 build_spec = 'NI ECAT Remote IO'
 bitness = '64'
-bitness_versions = ['2021']
+bitness_versions = ['2021', '2023']
 
 [[build.steps]]
 name = 'Scan Engine Remote IO Libraries'
@@ -39,7 +39,7 @@ project = '{modules}'
 target = 'Linux x64'
 build_spec = 'NI ECAT Remote IO'
 bitness = '32'
-bitness_versions = ['2021']
+bitness_versions = ['2021', '2023']
 
 [notification]
 type = 'teams'


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-module-libraries/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Create a LV 2023-based build of the modules libraries.

Note: leaving 2019 enabled until we disable it from all dependent repos.

### Why should this Pull Request be merged?

We need a good build against in-dev 2023 to run automated testing.

### What testing has been done?

PR build.

