### PR TITLE
Drop 32bit lv support

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,15 +19,9 @@ stages:
 
       lvVersionsToBuild:
         - version: '2023'
-          bitness: '32bit'
-        - version: '2023'
           bitness: '64bit'
         - version: '2024'
-          bitness: '32bit'
-        - version: '2024'
           bitness: '64bit'
-        - version: '2025'
-          bitness: '32bit'
         - version: '2025'
           bitness: '64bit'
 
@@ -36,13 +30,6 @@ stages:
           buildOperation: 'ExecuteBuildSpec'
           target: 'My Computer'
           buildSpec: 'Modules'
-          exclusions:
-            - version: '2023'
-              bitness: '32bit'
-            - version: '2024'
-              bitness: '32bit'
-            - version: '2025'
-              bitness: '32bit'
 
         - projectLocation: 'Source\Modules.lvproj'
           buildOperation: 'ExecuteBuildSpec'
@@ -60,13 +47,6 @@ stages:
           buildOperation: 'ExecuteBuildSpec'
           target: 'My Computer'
           buildSpec: 'NI ECAT Remote IO'
-          exclusions:
-            - version: '2023'
-              bitness: '32bit'
-            - version: '2024'
-              bitness: '32bit'
-            - version: '2025'
-              bitness: '32bit'
 
         - projectLocation: 'Source\Modules.lvproj'
           buildOperation: 'ExecuteBuildSpec'


### PR DESCRIPTION
- [ X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-module-libraries/blob/main/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-module-libraries/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Dropped 32 bit lv support testing as we are no longer supporting the 32 bit lv's.

### Why should this Pull Request be merged?

Required for future release.

### What testing has been done?

PR Build.
