### PR TITLE
Revert "Drop 32bit lv support (#59)"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,9 +19,15 @@ stages:
 
       lvVersionsToBuild:
         - version: '2023'
+          bitness: '32bit'
+        - version: '2023'
           bitness: '64bit'
         - version: '2024'
+          bitness: '32bit'
+        - version: '2024'
           bitness: '64bit'
+        - version: '2025'
+          bitness: '32bit'
         - version: '2025'
           bitness: '64bit'
 
@@ -30,6 +36,13 @@ stages:
           buildOperation: 'ExecuteBuildSpec'
           target: 'My Computer'
           buildSpec: 'Modules'
+          exclusions:
+            - version: '2023'
+              bitness: '32bit'
+            - version: '2024'
+              bitness: '32bit'
+            - version: '2025'
+              bitness: '32bit'
 
         - projectLocation: 'Source\Modules.lvproj'
           buildOperation: 'ExecuteBuildSpec'
@@ -47,6 +60,13 @@ stages:
           buildOperation: 'ExecuteBuildSpec'
           target: 'My Computer'
           buildSpec: 'NI ECAT Remote IO'
+          exclusions:
+            - version: '2023'
+              bitness: '32bit'
+            - version: '2024'
+              bitness: '32bit'
+            - version: '2025'
+              bitness: '32bit'
 
         - projectLocation: 'Source\Modules.lvproj'
           buildOperation: 'ExecuteBuildSpec'


### PR DESCRIPTION
This reverts commit 56ee1412960e77db0e62f1e792098887037c3e43.

- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-module-libraries/blob/main/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-module-libraries/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Reverted the changes related to dropping 32-bit LabVIEW support, as building the Scan Engine Custom Device requires LabVIEW 32-bit

### Why should this Pull Request be merged?

Required for future release.

### What testing has been done?

PR Build.
