### PR TITLE
Revert "Drop 32bit lv support (#62)"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,11 +18,11 @@ stages:
     parameters:
 
       lvVersionsToBuild:
-        - version: '2023'
-          bitness: '64bit'
         - version: '2024'
           bitness: '64bit'
         - version: '2025'
+          bitness: '64bit'
+        - version: '2026'
           bitness: '64bit'
 
       buildSteps:
@@ -36,11 +36,11 @@ stages:
           target: 'Linux x64'
           buildSpec: 'Modules'
           exclusions:
-            - version: '2023'
-              bitness: '64bit'
             - version: '2024'
               bitness: '64bit'
             - version: '2025'
+              bitness: '64bit'
+            - version: '2026'
               bitness: '64bit'
 
         - projectLocation: 'Source\Modules.lvproj'
@@ -53,13 +53,13 @@ stages:
           target: 'Linux x64'
           buildSpec: 'NI ECAT Remote IO'
           exclusions:
-            - version: '2023'
-              bitness: '64bit'
             - version: '2024'
               bitness: '64bit'
             - version: '2025'
               bitness: '64bit'
+            - version: '2026'
+              bitness: '64bit'
 
-      releaseVersion: '25.0.0'
+      releaseVersion: '26.0.0'
       buildOutputLocation: 'Built'
       archiveLocation: '\\nirvana\Measurements\VeriStandAddons\scan_engine_modules'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,15 +19,9 @@ stages:
 
       lvVersionsToBuild:
         - version: '2023'
-          bitness: '32bit'
-        - version: '2023'
           bitness: '64bit'
         - version: '2024'
-          bitness: '32bit'
-        - version: '2024'
           bitness: '64bit'
-        - version: '2025'
-          bitness: '32bit'
         - version: '2025'
           bitness: '64bit'
 
@@ -36,13 +30,6 @@ stages:
           buildOperation: 'ExecuteBuildSpec'
           target: 'My Computer'
           buildSpec: 'Modules'
-          exclusions:
-            - version: '2023'
-              bitness: '32bit'
-            - version: '2024'
-              bitness: '32bit'
-            - version: '2025'
-              bitness: '32bit'
 
         - projectLocation: 'Source\Modules.lvproj'
           buildOperation: 'ExecuteBuildSpec'
@@ -60,13 +47,6 @@ stages:
           buildOperation: 'ExecuteBuildSpec'
           target: 'My Computer'
           buildSpec: 'NI ECAT Remote IO'
-          exclusions:
-            - version: '2023'
-              bitness: '32bit'
-            - version: '2024'
-              bitness: '32bit'
-            - version: '2025'
-              bitness: '32bit'
 
         - projectLocation: 'Source\Modules.lvproj'
           buildOperation: 'ExecuteBuildSpec'


### PR DESCRIPTION
This reverts commit #62.

- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-module-libraries/blob/main/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-module-libraries/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Reverted the changes related to dropping 32-bit LabVIEW support, as building the Scan Engine Custom Device requires LabVIEW 32-bit

### Why should this Pull Request be merged?

Required for future release.

### What testing has been done?

PR Build.
