### PR TITLE
Adding restrictions in niveristand-scan-engine-module-libraries pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,13 +5,17 @@ trigger:
       - main
       - release/*
 
+variables:
+  - name: ConvertNetCore
+    value: false
+
 resources:
   repositories:
     - repository: niveristand-custom-device-build-tools
-      type:       github
-      ref:        main
-      endpoint:   nivs-custom-devices
-      name:       ni/niveristand-custom-device-build-tools
+      type: github
+      ref: main
+      endpoint: nivs-custom-devices
+      name: ni/niveristand-custom-device-build-tools
 
 stages:
   - template: azure-templates/stages.yml@niveristand-custom-device-build-tools
@@ -84,4 +88,3 @@ stages:
       buildOutputLocation: 'Built'
       archiveLocation: '\\nirvana\Measurements\VeriStandAddons\scan_engine_modules'
       repoName: 'niveristand-scan-engine-module-libraries'
-      createNetCoreRepo: true


### PR DESCRIPTION
- [ ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-module-libraries/blob/main/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-module-libraries/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adding restrictions in pipeline run

### Why should this Pull Request be merged?

Added variable to decide netcore conv

### What testing has been done?

none
